### PR TITLE
refactor(app): change the code of context API in a more Redux like style to make the code cleaner

### DIFF
--- a/src/components/Gallery/index.js
+++ b/src/components/Gallery/index.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react'
-import { useGlobalContext } from '../../contexts/AppContext'
+import { ACTIONS, useGlobalContext } from '../../contexts/AppContext'
 import styled from 'styled-components'
 import AnimalCard from '../AnimalCard'
 import PlayCard from '../PlayCard'
@@ -11,14 +11,15 @@ import {
 } from 'react-icons/fc'
 
 const Gallery = ({ mode }) => {
-  const { animals, loading, searchTerm, setSearchTerm } = useGlobalContext()
+  const { state, dispatch } = useGlobalContext()
+  const { animals, loading, searchTerm } = state
 
   // Local copy of the fetched animals, so that we can sort and filter on it
   const [localAnimals, setLocalAnimals] = useState([])
   useEffect(() => {
-    setSearchTerm('')
+    dispatch({ type: ACTIONS.SET_SEARCHTERM, payload: { searchTerm: '' } })
     setLocalAnimals(animals)
-  }, [animals, setSearchTerm])
+  }, [animals, dispatch])
 
   //  Use the filter to implement the search function
   useEffect(() => {

--- a/src/components/Playbar/index.js
+++ b/src/components/Playbar/index.js
@@ -1,14 +1,13 @@
 import React, { useRef, useContext } from 'react'
 import styled from 'styled-components'
 import { PlayContext } from '../../pages/Play'
-import { useGlobalContext } from '../../contexts/AppContext'
+import { ACTIONS, useGlobalContext } from '../../contexts/AppContext'
 import { FcSearch } from 'react-icons/fc'
 
 const Playbar = () => {
   const playButtonRef = useRef(null)
   const { playRandomSound, playing } = useContext(PlayContext)
-  const { setSearchTerm } = useGlobalContext()
-  const searchValue = useRef(null)
+  const { state, dispatch } = useGlobalContext()
   return (
     <Container>
       <h2>Which animal did you hear?</h2>
@@ -20,9 +19,14 @@ const Playbar = () => {
         <input
           id='name'
           type='text'
-          ref={searchValue}
+          value={state.searchTerm}
           placeholder='Search...'
-          onChange={() => setSearchTerm(searchValue.current.value)}
+          onChange={(e) =>
+            dispatch({
+              type: ACTIONS.SET_SEARCHTERM,
+              payload: { searchTerm: e.target.value },
+            })
+          }
         />
       </SearchContainer>
     </Container>

--- a/src/components/SearchForm/index.js
+++ b/src/components/SearchForm/index.js
@@ -1,8 +1,8 @@
 import React, { useRef, useEffect } from 'react'
-import { useGlobalContext } from '../../contexts/AppContext'
+import { ACTIONS, useGlobalContext } from '../../contexts/AppContext'
 
 const SearchForm = () => {
-  const { setSearchTerm } = useGlobalContext()
+  const { state, dispatch } = useGlobalContext()
   const searchValue = useRef(null)
   const handleSubmit = (e) => {
     e.preventDefault()
@@ -19,7 +19,13 @@ const SearchForm = () => {
           id='name'
           type='text'
           ref={searchValue}
-          onChange={() => setSearchTerm(searchValue.current.value)}
+          value={state.searchTerm}
+          onChange={(e) =>
+            dispatch({
+              type: ACTIONS.SET_SEARCHTERM,
+              payload: { searchTerm: e.target.value },
+            })
+          }
         />
       </form>
     </section>

--- a/src/components/Viewers/index.js
+++ b/src/components/Viewers/index.js
@@ -1,9 +1,12 @@
 import React from 'react'
 import styled from 'styled-components'
-import { useGlobalContext } from '../../contexts/AppContext'
+import { ACTIONS, useGlobalContext } from '../../contexts/AppContext'
 
 function Viewers() {
-  const { setAnimalType } = useGlobalContext()
+  const { dispatch } = useGlobalContext()
+  const setAnimalType = (animalType) => {
+    dispatch({ type: ACTIONS.SET_ANIMALTYPE, payload: { animalType } })
+  }
   return (
     <Container>
       <Wrap onClick={() => setAnimalType('')} aniType='all'>

--- a/src/contexts/AppContext.js
+++ b/src/contexts/AppContext.js
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useReducer, useCallback } from 'react'
+import React, { useContext, useEffect, useReducer } from 'react'
 import { animalsRef, getDocs } from '../firebase'
 import { query, orderBy, limit, where } from 'firebase/firestore'
 
@@ -12,7 +12,7 @@ const initialState = {
 }
 
 // Avoid hardcoded action strings, to reduce the bugs
-const ACTIONS = {
+export const ACTIONS = {
   SET_ANIMALS: 'SET_ANIMALS',
   OPEN_LOADING: 'OPEN_LOADING',
   CLOSE_LOADING: 'CLOSE_LOADING',
@@ -69,22 +69,11 @@ const AppProvider = ({ children }) => {
     loadAnimals(q)
   }, [state.animalType])
 
-  // For referential equality as this function is in the dependency array of another hook
-  const setSearchTerm = useCallback(
-    (searchTerm) =>
-      dispatch({ type: ACTIONS.SET_SEARCHTERM, payload: { searchTerm } }),
-    []
-  )
-
   return (
     <AppContext.Provider
       value={{
-        animals: state.animals,
-        searchTerm: state.searchTerm,
-        setSearchTerm,
-        loading: state.loading,
-        setAnimalType: (animalType) =>
-          dispatch({ type: ACTIONS.SET_ANIMALTYPE, payload: { animalType } }),
+        state,
+        dispatch,
       }}
     >
       {children}

--- a/src/pages/Play.js
+++ b/src/pages/Play.js
@@ -6,7 +6,9 @@ import { useGlobalContext } from '../contexts/AppContext'
 export const PlayContext = React.createContext()
 
 const Play = () => {
-  const { animals } = useGlobalContext()
+  const {
+    state: { animals },
+  } = useGlobalContext()
   const [playing, setPlaying] = useState(false)
 
   // useRef does not trigger the re-render


### PR DESCRIPTION


Since the app is using the combination of useReducer and useContext to perform the state management,
we change the value object of the context API to be more Redux like style. Now we can destructure
the state and dispatch from the context API in each componment, which is more consistent.