### PR TITLE
refactor(app): replace action objects with action creators

### DIFF
--- a/src/components/Gallery/index.js
+++ b/src/components/Gallery/index.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react'
-import { ACTIONS, useGlobalContext } from '../../contexts/AppContext'
+import { useGlobalContext, setSearchTerm } from '../../contexts/AppContext'
 import styled from 'styled-components'
 import AnimalCard from '../AnimalCard'
 import PlayCard from '../PlayCard'
@@ -17,7 +17,7 @@ const Gallery = ({ mode }) => {
   // Local copy of the fetched animals, so that we can sort and filter on it
   const [localAnimals, setLocalAnimals] = useState([])
   useEffect(() => {
-    dispatch({ type: ACTIONS.SET_SEARCHTERM, payload: { searchTerm: '' } })
+    dispatch(setSearchTerm(''))
     setLocalAnimals(animals)
   }, [animals, dispatch])
 

--- a/src/components/Playbar/index.js
+++ b/src/components/Playbar/index.js
@@ -1,7 +1,7 @@
 import React, { useRef, useContext } from 'react'
 import styled from 'styled-components'
 import { PlayContext } from '../../pages/Play'
-import { ACTIONS, useGlobalContext } from '../../contexts/AppContext'
+import { useGlobalContext, setSearchTerm } from '../../contexts/AppContext'
 import { FcSearch } from 'react-icons/fc'
 
 const Playbar = () => {
@@ -21,12 +21,7 @@ const Playbar = () => {
           type='text'
           value={state.searchTerm}
           placeholder='Search...'
-          onChange={(e) =>
-            dispatch({
-              type: ACTIONS.SET_SEARCHTERM,
-              payload: { searchTerm: e.target.value },
-            })
-          }
+          onChange={(e) => dispatch(setSearchTerm(e.target.value))}
         />
       </SearchContainer>
     </Container>

--- a/src/components/SearchForm/index.js
+++ b/src/components/SearchForm/index.js
@@ -1,5 +1,5 @@
 import React, { useRef, useEffect } from 'react'
-import { ACTIONS, useGlobalContext } from '../../contexts/AppContext'
+import { setSearchTerm, useGlobalContext } from '../../contexts/AppContext'
 
 const SearchForm = () => {
   const { state, dispatch } = useGlobalContext()
@@ -20,12 +20,7 @@ const SearchForm = () => {
           type='text'
           ref={searchValue}
           value={state.searchTerm}
-          onChange={(e) =>
-            dispatch({
-              type: ACTIONS.SET_SEARCHTERM,
-              payload: { searchTerm: e.target.value },
-            })
-          }
+          onChange={(e) => dispatch(setSearchTerm(e.target.value))}
         />
       </form>
     </section>

--- a/src/components/Viewers/index.js
+++ b/src/components/Viewers/index.js
@@ -1,30 +1,33 @@
 import React from 'react'
 import styled from 'styled-components'
-import { ACTIONS, useGlobalContext } from '../../contexts/AppContext'
+import { setAnimalType, useGlobalContext } from '../../contexts/AppContext'
 
 function Viewers() {
   const { dispatch } = useGlobalContext()
-  const setAnimalType = (animalType) => {
-    dispatch({ type: ACTIONS.SET_ANIMALTYPE, payload: { animalType } })
-  }
   return (
     <Container>
-      <Wrap onClick={() => setAnimalType('')} aniType='all'>
+      <Wrap onClick={() => dispatch(setAnimalType(''))} aniType='all'>
         <img src='/images/all.png' alt='all animals' />
       </Wrap>
-      <Wrap onClick={() => setAnimalType('mammal')} aniType='mammals'>
+      <Wrap onClick={() => dispatch(setAnimalType('mammal'))} aniType='mammals'>
         <img src='/images/mammal.png' alt='mammal' />
       </Wrap>
-      <Wrap onClick={() => setAnimalType('bird')} aniType='birds'>
+      <Wrap onClick={() => dispatch(setAnimalType('bird'))} aniType='birds'>
         <img src='/images/bird.png' alt='bird' />
       </Wrap>
-      <Wrap onClick={() => setAnimalType('amphibian')} aniType='amphibians'>
+      <Wrap
+        onClick={() => dispatch(setAnimalType('amphibian'))}
+        aniType='amphibians'
+      >
         <img src='/images/amphibian.png' alt='amphibian' />
       </Wrap>
-      <Wrap onClick={() => setAnimalType('reptile')} aniType='reptiles'>
+      <Wrap
+        onClick={() => dispatch(setAnimalType('reptile'))}
+        aniType='reptiles'
+      >
         <img src='/images/reptile.png' alt='reptile' />
       </Wrap>
-      <Wrap onClick={() => setAnimalType('insect')} aniType='insects'>
+      <Wrap onClick={() => dispatch(setAnimalType('insect'))} aniType='insects'>
         <img src='/images/insect.png' alt='insect' />
       </Wrap>
     </Container>

--- a/src/contexts/AppContext.js
+++ b/src/contexts/AppContext.js
@@ -20,6 +20,40 @@ export const ACTIONS = {
   SET_ANIMALTYPE: 'SET_ANIMALTYPE',
 }
 
+// Action creators
+export const setAnimals = (animals) => {
+  return {
+    type: ACTIONS.SET_ANIMALS,
+    payload: { animals },
+  }
+}
+
+export const openLoading = () => {
+  return {
+    type: ACTIONS.OPEN_LOADING,
+  }
+}
+
+export const closeLoading = () => {
+  return {
+    type: ACTIONS.CLOSE_LOADING,
+  }
+}
+
+export const setSearchTerm = (searchTerm) => {
+  return {
+    type: ACTIONS.SET_SEARCHTERM,
+    payload: { searchTerm },
+  }
+}
+
+export const setAnimalType = (animalType) => {
+  return {
+    type: ACTIONS.SET_ANIMALTYPE,
+    payload: { animalType },
+  }
+}
+
 function reducer(state, action) {
   switch (action.type) {
     case ACTIONS.SET_ANIMALS:
@@ -44,18 +78,18 @@ const AppProvider = ({ children }) => {
   // Fetch the animals from server when animalType changes
   useEffect(() => {
     const loadAnimals = async (animalQuery) => {
-      dispatch({ type: ACTIONS.OPEN_LOADING })
+      dispatch(openLoading())
       try {
         const querySnapshot = await getDocs(animalQuery)
         const result = []
         querySnapshot.forEach((doc) => {
           result.push(doc.data())
         })
-        dispatch({ type: ACTIONS.SET_ANIMALS, payload: { animals: result } })
+        dispatch(setAnimals(result))
       } catch (err) {
         console.log(err)
       } finally {
-        dispatch({ type: ACTIONS.CLOSE_LOADING })
+        dispatch(closeLoading())
       }
     }
     const animalQuery = query(animalsRef, orderBy('name', 'desc'), limit(100))


### PR DESCRIPTION
Instead of creating the action objects mannually every where across the components, we use the
action creators to make the code more maintainable, testable and cleaner. In the case when we need
to modify the action, we no longer need to find all the places and update them all, we can instead
just modify the action creator.